### PR TITLE
Demo for suggestion-chips

### DIFF
--- a/functions/assets/raw_data_land_chips.json
+++ b/functions/assets/raw_data_land_chips.json
@@ -1,0 +1,4 @@
+[
+    {"land":"cropland"},{"land":"forest land"},{"land":"grassland"},{"land":"Burning Biomass"}
+
+]

--- a/functions/land.js
+++ b/functions/land.js
@@ -1,12 +1,33 @@
 var config = require('./config')
 const requestLib = require('request');
 const utils = require('./utils');
+const path=require('path');
+
+const fs = require('fs');
 
 exports.processRequest = function(conv, parameters) {
     return new Promise(function(resolve, reject) {
-        if (parameters.land_type !== "" && parameters.land_region !== "") {
-            let land_type = parameters.land_type;
+        if (parameters.land_region !== "") {
             let land_region = parameters.land_region;
+            let land_type = parameters.land_type;
+            let land_types = []
+            if (parameters.land_type === ""){
+             
+                fs.readFile(path.join(__dirname, './assets/raw_data_land_chips.json'), function(err, data) {
+                    if (err) {
+                        return console.log(err);
+                    }
+                    console.log("data: ", JSON.parse(data));
+                    data = JSON.parse(data);
+                    data.forEach((obj) => {
+                        console.log("land", obj.land);
+                        land_types.push(obj.land);
+                    });
+                    utils.responseWithSuggestions(conv, "Please select from the following types of lands", land_types);
+                    resolve();
+                    return;
+                });
+            }
             var options = {
                 uri: config.endpoint + "/land",
                 method: 'POST',
@@ -52,6 +73,4 @@ exports.processRequest = function(conv, parameters) {
             resolve();
         }
     });
-    
 }
-


### PR DESCRIPTION
This PR provides a small demo for the suggestion chips supports in various emission categories.
As the user will be unaware of the input types in various emission categories, adding a few suggestion chips in the categories will make the action more user-friendly. Here in this demo, the various land_types are organized in a separate JSON file then the data is first extracted and send for the suggestion chips.
Here's a [preview](https://drive.google.com/file/d/1xQWJCqVJMsqX0EnofgrzR3TC4_JdG6Fa/view?usp=sharing)